### PR TITLE
Fix unhandled exception when no templates have been configured

### DIFF
--- a/lib/consult.rb
+++ b/lib/consult.rb
@@ -25,7 +25,7 @@ module Consult
       yaml = root.join('config', 'consult.yml')
       @config = yaml.exist? ? YAML.safe_load(ERB.new(yaml.read).result, [], [], true) : {}
       @config.deep_symbolize_keys!
-      @templates = @config[:templates]&.map { |name, config| Template.new(name, config) }
+      @templates = @config[:templates]&.map { |name, config| Template.new(name, config) } || []
 
       configure_consul
       configure_vault

--- a/lib/consult.rb
+++ b/lib/consult.rb
@@ -58,11 +58,11 @@ module Consult
     end
 
     def root(directory: nil)
-      @_root ||= directory ? Pathname.new(directory) : (!!defined?(Rails) && ::Rails.root)
+      @_root ||= directory ? Pathname.new(directory) : (defined?(::Rails) && ::Rails.root)
     end
 
     def env
-      @config[:env] || ENV['RAILS_ENV'] || Rails.env
+      @config[:env] || ENV['RAILS_ENV'] || (defined?(::Rails) && ::Rails.root)
     end
 
     # Return only the templates that are relevant for the current environment

--- a/lib/consult/template.rb
+++ b/lib/consult/template.rb
@@ -34,7 +34,7 @@ module Consult
     end
 
     def should_render?
-      (@config[:environments] == 'all' || @config[:environments].include?(Consult.env)) && expired?
+      (@config[:environments] == 'all' || [@config[:environments]].flatten.include?(Consult.env)) && expired?
     end
 
     def expired?


### PR DESCRIPTION
Got this when introducing consult to an app, where I hadn't added the config/consult.yml file yet. The code appears to otherwise support booting up without a config file, except for 1 unhandled exception.

This fixes #1