### PR TITLE
Support multiple file sources for a single template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@
 /doc/
 /pkg/
 /spec/reports/
-/spec/support/rendered/*.yml
+/spec/support/rendered/*
 /tmp/
 
 # rspec failure tracking

--- a/lib/consult/template.rb
+++ b/lib/consult/template.rb
@@ -15,7 +15,7 @@ module Consult
     end
 
     def render(save: true)
-      renderer = ERB.new(File.read(path, encoding: 'utf-8'), nil, '-')
+      renderer = ERB.new(contents, nil, '-')
       result = renderer.result(binding)
 
       File.open(dest, 'w') { |f| f << result } if save
@@ -26,7 +26,15 @@ module Consult
     end
 
     def path
-      resolve @config.fetch(:path)
+      resolve @config[:path]
+    end
+
+    def paths
+      @config.fetch(:paths, []).map { |path| resolve(path) }
+    end
+
+    def vars
+      @config[:vars]
     end
 
     def dest
@@ -41,6 +49,15 @@ module Consult
       # Treat renders as expired if a TTL isn't set, or it has never been rendered before
       return true if !config.key?(:ttl) || !dest.exist?
       dest.mtime < (Time.now - @config[:ttl].to_i)
+    end
+
+    private
+
+    # Concatenate all the source templates together, in the order provided
+    def contents
+      [path, paths].compact.flatten.map do |file_path|
+        File.read file_path, encoding: 'utf-8'
+      end.join
     end
   end
 end

--- a/lib/consult/utilities.rb
+++ b/lib/consult/utilities.rb
@@ -3,6 +3,7 @@
 module Consult
   module Utilities
     def resolve(path)
+      return unless path
       pathname = Pathname.new(path)
       pathname.relative? ? Consult.root.join(pathname) : pathname
     end

--- a/spec/consult_spec.rb
+++ b/spec/consult_spec.rb
@@ -21,5 +21,10 @@ RSpec.describe Consult do
 
   it 'renders without error' do
     expect { Consult.render! }.to_not raise_exception
+
+    # Verify text templates rendered correctly
+    %w[elements.txt more_elements.txt].each do |template|
+      expect(FileUtils.compare_file("spec/support/expected/#{template}", "spec/support/rendered/#{template}")).to be true
+    end
   end
 end

--- a/spec/support/config/consult.yml
+++ b/spec/support/config/consult.yml
@@ -14,6 +14,26 @@ shared:
       dest: rendered/database.yml
       ttl: 10 # seconds
 
+    elements:
+      paths:
+        - templates/elements/air.txt
+        - templates/elements/fire.txt
+      dest: rendered/elements.txt
+      vars:
+        air: 1
+        fire: 2
+
+    more_elements:
+      path: templates/elements/air.txt
+      paths:
+        - templates/elements/fire.txt
+        - templates/elements/water.txt
+      dest: rendered/more_elements.txt
+      vars:
+        air: 1
+        fire: 2
+        water: 3
+
 test:
   templates:
     secrets:

--- a/spec/support/expected/elements.txt
+++ b/spec/support/expected/elements.txt
@@ -1,0 +1,2 @@
+Air is the 1st element
+Fire is the 2nd element

--- a/spec/support/expected/more_elements.txt
+++ b/spec/support/expected/more_elements.txt
@@ -1,0 +1,3 @@
+Air is the 1st element
+Fire is the 2nd element
+Water is the 3rd element

--- a/spec/support/templates/elements/air.txt
+++ b/spec/support/templates/elements/air.txt
@@ -1,0 +1,1 @@
+Air is the <%= vars[:air] %>st element

--- a/spec/support/templates/elements/fire.txt
+++ b/spec/support/templates/elements/fire.txt
@@ -1,0 +1,1 @@
+Fire is the <%= vars[:fire] %>nd element

--- a/spec/support/templates/elements/water.txt
+++ b/spec/support/templates/elements/water.txt
@@ -1,0 +1,1 @@
+Water is the <%= vars[:water] %>rd element


### PR DESCRIPTION
This will concatenate the contents of each file together to form a single template, which will then be rendered once. This addresses #6.

Technically we support both `:path` and `:paths` at the same time, but that's a silly scenario. However, it's not worth preventing.

This also adds support for a `vars` block in the template configuration file, which could be useful for relatively static values, or situations where you are sharing a template across multiple code bases.