### PR TITLE
Support Consul-sourced template files

### DIFF
--- a/lib/consult/template.rb
+++ b/lib/consult/template.rb
@@ -54,7 +54,19 @@ module Consult
     private
 
     # Concatenate all the source templates together, in the order provided
+    # Disk contents go first
     def contents
+      disk_contents + consul_contents
+    end
+
+    def consul_contents
+      [@config[:consul_key], @config[:consul_keys]].compact.flatten.map do |key|
+        Diplomat::Kv.get(key, options: nil, not_found: :return, found: :return)
+      end.join
+    end
+
+    # Concatenate all the source templates together, in the order provided
+    def disk_contents
       [path, paths].compact.flatten.map do |file_path|
         File.read file_path, encoding: 'utf-8'
       end.join

--- a/spec/consult_spec.rb
+++ b/spec/consult_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Consult do
     expect { Consult.render! }.to_not raise_exception
 
     # Verify text templates rendered correctly
-    %w[elements.txt more_elements.txt].each do |template|
+    %w[elements.txt more_elements.txt consul_elements.txt more_consul_elements.txt multi_pass.txt].each do |template|
       expect(FileUtils.compare_file("spec/support/expected/#{template}", "spec/support/rendered/#{template}")).to be true
     end
   end

--- a/spec/support/config/consult.yml
+++ b/spec/support/config/consult.yml
@@ -34,6 +34,44 @@ shared:
         fire: 2
         water: 3
 
+    consul_elements:
+      consul_keys:
+        - templates/elements/earth
+        - templates/elements/love
+      dest: rendered/consul_elements.txt
+      vars:
+        earth: 4
+        love: 5
+
+    more_consul_elements:
+      consul_key: templates/elements/earth
+      consul_keys:
+        - templates/elements/love
+        - templates/elements/aziz
+      dest: rendered/more_consul_elements.txt
+      vars:
+        earth: 4
+        love: 5
+        aziz: 'Light!'
+      
+    multi_pass:
+      path: templates/elements/air.txt
+      paths:
+        - templates/elements/fire.txt
+        - templates/elements/water.txt
+      consul_key: templates/elements/earth
+      consul_keys:
+        - templates/elements/love
+        - templates/elements/aziz
+      dest: rendered/multi_pass.txt
+      vars:
+        air: 1
+        fire: 2
+        water: 3
+        earth: 4
+        love: 5
+        aziz: 'Light!'
+
 test:
   templates:
     secrets:

--- a/spec/support/expected/consul_elements.txt
+++ b/spec/support/expected/consul_elements.txt
@@ -1,0 +1,2 @@
+Earth is the 4th element
+Love is the 5th element!

--- a/spec/support/expected/more_consul_elements.txt
+++ b/spec/support/expected/more_consul_elements.txt
@@ -1,0 +1,3 @@
+Earth is the 4th element
+Love is the 5th element!
+Aziz! Light!

--- a/spec/support/expected/multi_pass.txt
+++ b/spec/support/expected/multi_pass.txt
@@ -1,0 +1,6 @@
+Air is the 1st element
+Fire is the 2nd element
+Water is the 3rd element
+Earth is the 4th element
+Love is the 5th element!
+Aziz! Light!

--- a/spec/support/populate_consul.sh
+++ b/spec/support/populate_consul.sh
@@ -13,3 +13,18 @@ curl \
     --request PUT \
     --data 'db1.local.net' \
     http://0.0.0.0:8500/v1/kv/infrastructure/db1/dns
+
+curl \
+    --request PUT \
+    --data $'Earth is the <%= vars[:earth] %>th element\n' \
+    http://0.0.0.0:8500/v1/kv/templates/elements/earth
+
+curl \
+    --request PUT \
+    --data $'Love is the <%= vars[:love] %>th element!\n' \
+    http://0.0.0.0:8500/v1/kv/templates/elements/love
+
+curl \
+    --request PUT \
+    --data $'Aziz! <%= vars[:aziz] %>\n' \
+    http://0.0.0.0:8500/v1/kv/templates/elements/aziz


### PR DESCRIPTION
Working off of #14, this will concatenate the contents of each Consul key and file specified to form a single template which will be rendered once. This also addresses #6. 

Similar to #14, both `:consul_key` and `:consul_keys` are supported but this is more for completeness than functionality.

The `vars` block continues to be supported with Consul key sources. 

While delimiters between source blocks (a `join_delimiter` such as a newline) are not supported, one can specify this in a file or Consul key source. If posting data to Consul using a tool like `curl`, one can specify delimiters like this:

```
$ curl \
    --request PUT \
    --data $'Aziz! <%= vars[:aziz] %>\n' \
    http://0.0.0.0:8500/v1/kv/templates/elements/aziz
```