### PR TITLE
Support safe template re-rendering

### DIFF
--- a/lib/consult.rb
+++ b/lib/consult.rb
@@ -19,7 +19,6 @@ module Consult
 
   class << self
     attr_reader :config, :templates
-
     def load(config_dir: nil)
       root directory: config_dir
       yaml = root.join('config', 'consult.yml')

--- a/lib/consult/template.rb
+++ b/lib/consult/template.rb
@@ -15,14 +15,16 @@ module Consult
     end
 
     def render(save: true)
+      # Attempt to render
       renderer = ERB.new(contents, nil, '-')
       result = renderer.result(binding)
 
       File.open(dest, 'w') { |f| f << result } if save
       result
     rescue StandardError => e
-      puts "Error rendering template: #{name}"
-      raise e
+      STDERR.puts "Error rendering template: #{name}"
+      STDERR.puts e
+      nil
     end
 
     def path

--- a/spec/lib/template_spec.rb
+++ b/spec/lib/template_spec.rb
@@ -9,7 +9,15 @@ RSpec.describe Consult::Template do
       ttl: 2
     }
   end
+  let(:fail_config) do
+    {
+      consul_key: 'templates/elements/aziz',
+      dest: 'rendered/nope/dest_fail.keep',
+      vars: {aziz: 'Light!'}
+    }
+  end
   let(:template) { Consult::Template.new(name, config) }
+  let(:fail_template) { Consult::Template.new('aziz', fail_config) }
 
   before :all do
     Consult.load config_dir: 'spec/support'
@@ -39,6 +47,10 @@ RSpec.describe Consult::Template do
     expect(template.expired?).to be(false)
     sleep 2
     expect(template.should_render?).to be(true)
+  end
+
+  it 'outputs render failures to stderr' do
+    expect { fail_template.render }.to output(/Error rendering template*/).to_stderr_from_any_process
   end
 
   context 'template functions' do

--- a/spec/support/config/consult.yml
+++ b/spec/support/config/consult.yml
@@ -53,7 +53,7 @@ shared:
         earth: 4
         love: 5
         aziz: 'Light!'
-      
+
     multi_pass:
       path: templates/elements/air.txt
       paths:
@@ -70,6 +70,12 @@ shared:
         water: 3
         earth: 4
         love: 5
+        aziz: 'Light!'
+
+    dest_fail:
+      consul_key: templates/elements/aziz
+      dest: rendered/nope/dest_fail.keep
+      vars:
         aziz: 'Light!'
 
 test:


### PR DESCRIPTION
This is a work in progress based on #15, partially addressing #13.

The desire is to safely account for disk path and Consul key lookup errors as well as disk I/O errors (when attempting to render the final unified template) without affecting the previously-rendered template. 

Custom error handling will be addresses in a separate PR.
