### PR TITLE
Support custom error handlers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@
 /doc/
 /pkg/
 /spec/reports/
-/spec/support/rendered/*.yml
+/spec/support/rendered/*
 /tmp/
 
 # rspec failure tracking

--- a/lib/consult.rb
+++ b/lib/consult.rb
@@ -19,6 +19,7 @@ module Consult
 
   class << self
     attr_reader :config, :templates
+    attr_writer :exception_handler
 
     def load(config_dir: nil)
       root directory: config_dir
@@ -76,6 +77,10 @@ module Consult
     # Render templates.
     def render!
       active_templates.each(&:render)
+    end
+
+    def exception_handler
+      @exception_handler ||= ->(e) { puts e.message }
     end
 
     # Map more conventional `token` parameter to Diplomat's `acl_token` configuration.

--- a/lib/consult/template.rb
+++ b/lib/consult/template.rb
@@ -56,7 +56,19 @@ module Consult
     private
 
     # Concatenate all the source templates together, in the order provided
+    # Disk contents go first
     def contents
+      disk_contents + consul_contents
+    end
+
+    def consul_contents
+      [@config[:consul_key], @config[:consul_keys]].compact.flatten.map do |key|
+        Diplomat::Kv.get(key, options: nil, not_found: :return, found: :return)
+      end.join
+    end
+
+    # Concatenate all the source templates together, in the order provided
+    def disk_contents
       [path, paths].compact.flatten.map do |file_path|
         File.read file_path, encoding: 'utf-8'
       end.join

--- a/lib/consult/template.rb
+++ b/lib/consult/template.rb
@@ -15,14 +15,15 @@ module Consult
     end
 
     def render(save: true)
+      # Attempt to render
       renderer = ERB.new(contents, nil, '-')
       result = renderer.result(binding)
 
       File.open(dest, 'w') { |f| f << result } if save
       result
     rescue StandardError => e
-      puts "Error rendering template: #{name}"
-      raise e
+      Consult.exception_handler.call(e)
+      nil
     end
 
     def path

--- a/spec/consult_spec.rb
+++ b/spec/consult_spec.rb
@@ -21,5 +21,10 @@ RSpec.describe Consult do
 
   it 'renders without error' do
     expect { Consult.render! }.to_not raise_exception
+
+    # Verify text templates rendered correctly
+    %w[elements.txt more_elements.txt].each do |template|
+      expect(FileUtils.compare_file("spec/support/expected/#{template}", "spec/support/rendered/#{template}")).to be true
+    end
   end
 end

--- a/spec/consult_spec.rb
+++ b/spec/consult_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Consult do
     expect { Consult.render! }.to_not raise_exception
 
     # Verify text templates rendered correctly
-    %w[elements.txt more_elements.txt].each do |template|
+    %w[elements.txt more_elements.txt consul_elements.txt more_consul_elements.txt multi_pass.txt].each do |template|
       expect(FileUtils.compare_file("spec/support/expected/#{template}", "spec/support/rendered/#{template}")).to be true
     end
   end

--- a/spec/support/config/consult.yml
+++ b/spec/support/config/consult.yml
@@ -14,6 +14,26 @@ shared:
       dest: rendered/database.yml
       ttl: 10 # seconds
 
+    elements:
+      paths:
+        - templates/elements/air.txt
+        - templates/elements/fire.txt
+      dest: rendered/elements.txt
+      vars:
+        air: 1
+        fire: 2
+
+    more_elements:
+      path: templates/elements/air.txt
+      paths:
+        - templates/elements/fire.txt
+        - templates/elements/water.txt
+      dest: rendered/more_elements.txt
+      vars:
+        air: 1
+        fire: 2
+        water: 3
+
 test:
   templates:
     secrets:

--- a/spec/support/config/consult.yml
+++ b/spec/support/config/consult.yml
@@ -34,6 +34,44 @@ shared:
         fire: 2
         water: 3
 
+    consul_elements:
+      consul_keys:
+        - templates/elements/earth
+        - templates/elements/love
+      dest: rendered/consul_elements.txt
+      vars:
+        earth: 4
+        love: 5
+
+    more_consul_elements:
+      consul_key: templates/elements/earth
+      consul_keys:
+        - templates/elements/love
+        - templates/elements/aziz
+      dest: rendered/more_consul_elements.txt
+      vars:
+        earth: 4
+        love: 5
+        aziz: 'Light!'
+      
+    multi_pass:
+      path: templates/elements/air.txt
+      paths:
+        - templates/elements/fire.txt
+        - templates/elements/water.txt
+      consul_key: templates/elements/earth
+      consul_keys:
+        - templates/elements/love
+        - templates/elements/aziz
+      dest: rendered/multi_pass.txt
+      vars:
+        air: 1
+        fire: 2
+        water: 3
+        earth: 4
+        love: 5
+        aziz: 'Light!'
+
 test:
   templates:
     secrets:

--- a/spec/support/config/consult.yml
+++ b/spec/support/config/consult.yml
@@ -53,7 +53,7 @@ shared:
         earth: 4
         love: 5
         aziz: 'Light!'
-      
+
     multi_pass:
       path: templates/elements/air.txt
       paths:
@@ -70,6 +70,12 @@ shared:
         water: 3
         earth: 4
         love: 5
+        aziz: 'Light!'
+
+    dest_fail:
+      consul_key: templates/elements/aziz
+      dest: rendered/nope/dest_fail.keep
+      vars:
         aziz: 'Light!'
 
 test:

--- a/spec/support/expected/consul_elements.txt
+++ b/spec/support/expected/consul_elements.txt
@@ -1,0 +1,2 @@
+Earth is the 4th element
+Love is the 5th element!

--- a/spec/support/expected/elements.txt
+++ b/spec/support/expected/elements.txt
@@ -1,0 +1,2 @@
+Air is the 1st element
+Fire is the 2nd element

--- a/spec/support/expected/more_consul_elements.txt
+++ b/spec/support/expected/more_consul_elements.txt
@@ -1,0 +1,3 @@
+Earth is the 4th element
+Love is the 5th element!
+Aziz! Light!

--- a/spec/support/expected/more_elements.txt
+++ b/spec/support/expected/more_elements.txt
@@ -1,0 +1,3 @@
+Air is the 1st element
+Fire is the 2nd element
+Water is the 3rd element

--- a/spec/support/expected/multi_pass.txt
+++ b/spec/support/expected/multi_pass.txt
@@ -1,0 +1,6 @@
+Air is the 1st element
+Fire is the 2nd element
+Water is the 3rd element
+Earth is the 4th element
+Love is the 5th element!
+Aziz! Light!

--- a/spec/support/populate_consul.sh
+++ b/spec/support/populate_consul.sh
@@ -16,11 +16,6 @@ curl \
 
 curl \
     --request PUT \
-    --data 'db1.local.net' \
-    http://0.0.0.0:8500/v1/kv/infrastructure/db1/dns
-
-curl \
-    --request PUT \
     --data $'Earth is the <%= vars[:earth] %>th element\n' \
     http://0.0.0.0:8500/v1/kv/templates/elements/earth
 

--- a/spec/support/populate_consul.sh
+++ b/spec/support/populate_consul.sh
@@ -13,3 +13,23 @@ curl \
     --request PUT \
     --data 'db1.local.net' \
     http://0.0.0.0:8500/v1/kv/infrastructure/db1/dns
+
+curl \
+    --request PUT \
+    --data 'db1.local.net' \
+    http://0.0.0.0:8500/v1/kv/infrastructure/db1/dns
+
+curl \
+    --request PUT \
+    --data $'Earth is the <%= vars[:earth] %>th element\n' \
+    http://0.0.0.0:8500/v1/kv/templates/elements/earth
+
+curl \
+    --request PUT \
+    --data $'Love is the <%= vars[:love] %>th element!\n' \
+    http://0.0.0.0:8500/v1/kv/templates/elements/love
+
+curl \
+    --request PUT \
+    --data $'Aziz! <%= vars[:aziz] %>\n' \
+    http://0.0.0.0:8500/v1/kv/templates/elements/aziz

--- a/spec/support/templates/elements/air.txt
+++ b/spec/support/templates/elements/air.txt
@@ -1,0 +1,1 @@
+Air is the <%= vars[:air] %>st element

--- a/spec/support/templates/elements/fire.txt
+++ b/spec/support/templates/elements/fire.txt
@@ -1,0 +1,1 @@
+Fire is the <%= vars[:fire] %>nd element

--- a/spec/support/templates/elements/water.txt
+++ b/spec/support/templates/elements/water.txt
@@ -1,0 +1,1 @@
+Water is the <%= vars[:water] %>rd element


### PR DESCRIPTION
This is a work in progress based on #16, partially addressing #13.

The desire is to allow custom error handling as defined by the caller and to provide a few basic error handers.

An example handler class is provided for testing as well as a very basic default which simply displays the error message.

Currently, caller-specified error handlers _may_ be ignored at initial render. See below. 

To do:

- [ ] Provide additional, possibly configurable default error handler options such as one that raises the thrown exception rather than simply displaying it and moving on. 
- [ ] Determine the initialization order such that caller-defined error handlers will exist before `Consult.render!` is executed.