### PR TITLE
Remove dependency on ActiveSupport

### DIFF
--- a/consult.gemspec
+++ b/consult.gemspec
@@ -24,7 +24,6 @@ Gem::Specification.new do |spec|
   spec.executables   = ['consult']
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'activesupport', '> 4', '< 6'
   spec.add_dependency 'diplomat', '~> 2.0.2'
   spec.add_dependency 'vault', '>= 0.10.0', '< 1.0.0'
 

--- a/lib/consult.rb
+++ b/lib/consult.rb
@@ -2,7 +2,6 @@
 
 require 'pathname'
 require 'yaml'
-require 'active_support/core_ext/hash'
 require 'erb'
 require 'vault'
 require 'diplomat'
@@ -10,6 +9,7 @@ require 'diplomat'
 require 'consult/version'
 require 'consult/utilities'
 require 'consult/template'
+require_relative './support/hash_extensions'
 
 module Consult
   @config = {}
@@ -45,7 +45,7 @@ module Consult
       @config[:consul][:url] = ENV['CONSUL_HTTP_ADDR'] || configured_address || @config[:consul][:url]
       # If a consul token exists, treat it as special
       # See https://github.com/WeAreFarmGeek/diplomat/pull/160
-      (@config[:consul][:options] ||= {}).merge!(headers: {'X-Consul-Token' => consul_token}) if consul_token.present?
+      (@config[:consul][:options] ||= {}).merge!(headers: {'X-Consul-Token' => consul_token}) if consul_token.to_s.length > 0
 
       Diplomat.configure do |c|
         @config[:consul].each do |opt, val|

--- a/lib/support/hash_extensions.rb
+++ b/lib/support/hash_extensions.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# ActiveSupport's corresponding methods
+#  - https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/hash
+module HashExtension
+  def deep_symbolize_keys!(object = self)
+    case object
+    when Hash
+      object.keys.each do |key|
+        value = object.delete key
+        object[key.to_sym] = deep_symbolize_keys! value
+      end
+      object
+    when Array
+      object.map! { |e| deep_symbolize_keys! e }
+    else
+      object
+    end
+  end
+
+  def deep_merge(other_hash, &block)
+    merge(other_hash) do |key, this_val, other_val|
+      if this_val.is_a?(Hash) && other_val.is_a?(Hash)
+        this_val.deep_merge other_val, &block
+      elsif block_given?
+        block.call key, this_val, other_val
+      else
+        other_val
+      end
+    end
+  end
+end
+
+Hash.send(:include, HashExtension)


### PR DESCRIPTION
Removes Consult's dependency on ActiveSupport.  It's one less dependency to manage and a smaller deployment package for projects that depend on Consult that aren't Rails apps.


Addresses https://github.com/veracross/consult/issues/26