### PR TITLE
Use YAML.safe_load option to symbolize config keys

### DIFF
--- a/lib/consult.rb
+++ b/lib/consult.rb
@@ -24,8 +24,7 @@ module Consult
       root directory: config_dir
       yaml = root.join('config', 'consult.yml')
 
-      @all_config = yaml.exist? ? YAML.safe_load(ERB.new(yaml.read).result, [], [], true).to_h : {}
-      @all_config.deep_symbolize_keys!
+      @all_config = yaml.exist? ? YAML.safe_load(ERB.new(yaml.read).result, [], [], true, symbolize_names: true).to_h : {}
 
       @config = @all_config[:shared].to_h.deep_merge @all_config[env&.to_sym].to_h
       @templates = @config[:templates]&.map { |name, config| Template.new(name, config.merge(verbose: verbose)) } || []

--- a/lib/support/hash_extensions.rb
+++ b/lib/support/hash_extensions.rb
@@ -3,21 +3,6 @@
 # ActiveSupport's corresponding methods
 #  - https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/hash
 module HashExtension
-  def deep_symbolize_keys!(object = self)
-    case object
-    when Hash
-      object.keys.each do |key|
-        value = object.delete key
-        object[key.to_sym] = deep_symbolize_keys! value
-      end
-      object
-    when Array
-      object.map! { |e| deep_symbolize_keys! e }
-    else
-      object
-    end
-  end
-
   def deep_merge(other_hash, &block)
     merge(other_hash) do |key, this_val, other_val|
       if this_val.is_a?(Hash) && other_val.is_a?(Hash)


### PR DESCRIPTION
As the title suggests, you can use the option, `symbolize_names: true`, to symbolize the keys recursively when reading a `yaml` file with ruby.

Please note that the tests **fail** when the option is `false` and **pass** when the option is `true`.  Also, note that the only place the method `deep_symbolize_keys!` (deleted in this PR) was being used was when loading the consult config file.

Below is an example usage of `YAML.safe_load` with the symbolize_names option set to true.

**YAML examples I cribbed from the internet**
```
---
job: Developer
employed: True
foods:
    - Apple
    - Orange
    - Strawberry
    - Mango
languages:
    ruby: yes
    python: no
    javascript: yes
multi_line: |
    this
    is
    multi line
en:
  formtastic:
    labels:
      title: "Title"  # Default global value
      article:
        body: "Article content"
      post:
        new:
          title: "Choose a title..."
          body: "Write something..."
        edit:
          title: "Edit title"
          body: "Edit body"
```

**Example using YAML.safe_load with `symbolize_names: true` (ruby 2.5.3)**

```ruby
YAML.safe_load(File.read('example.yml'), symbolize_names: true)

=> {:job=>"Developer",
 :employed=>true,
 :foods=>["Apple", "Orange", "Strawberry", "Mango"],
 :languages=>{:ruby=>true, :python=>false, :javascript=>true},
 :multi_line=>"this\nis\nmulti line\n",
 :en=>
  {:formtastic=>
    {:labels=>
      {:title=>"Title",
       :article=>{:body=>"Article content"},
       :post=>
        {:new=>{:title=>"Choose a title...", :body=>"Write something..."},
         :edit=>{:title=>"Edit title", :body=>"Edit body"}}}}}}
```