### PR TITLE
Refactor CircleCI to test multiple Ruby versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,7 @@
 version: 2
-jobs:
-  build:
+common_job_config: &common_job_config
     docker:
-      - image: circleci/ruby:2.5.3
+      - image: circleci/ruby:latest
       - image: consul:1.3.0
       - image: vault:0.11.3
         environment:
@@ -61,3 +60,35 @@ jobs:
       - store_artifacts:
           path: /tmp/test-results
           destination: test-results
+jobs:
+  ruby_27:
+    <<: *common_job_config
+    docker:
+      - image: circleci/ruby:2.7.0
+      - image: consul:1.3.0
+      - image: vault:0.11.3
+        environment:
+          - VAULT_DEV_ROOT_TOKEN_ID=94e1a9ed-5d72-5677-27ab-ebc485cca368
+  ruby_26:
+    <<: *common_job_config
+    docker:
+      - image: circleci/ruby:2.6.2
+      - image: consul:1.3.0
+      - image: vault:0.11.3
+        environment:
+          - VAULT_DEV_ROOT_TOKEN_ID=94e1a9ed-5d72-5677-27ab-ebc485cca368
+  ruby_25:
+    <<: *common_job_config
+    docker:
+      - image: circleci/ruby:2.5.3
+      - image: consul:1.3.0
+      - image: vault:0.11.3
+        environment:
+          - VAULT_DEV_ROOT_TOKEN_ID=94e1a9ed-5d72-5677-27ab-ebc485cca368
+workflows:
+  version: 2
+  supported_ruby_versions:
+    jobs:
+      - ruby_27
+      - ruby_26
+      - ruby_25

--- a/consult.gemspec
+++ b/consult.gemspec
@@ -27,7 +27,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'diplomat', '~> 2.0.2'
   spec.add_dependency 'vault', '>= 0.10.0', '< 1.0.0'
 
-  spec.add_development_dependency 'bundler', '~> 1.16'
   spec.add_development_dependency 'guard'
   spec.add_development_dependency 'guard-rspec'
   spec.add_development_dependency 'pry-byebug'


### PR DESCRIPTION
Refactor CircleCI to test multiple Ruby versions (Thanks @aharpervc for the idea and code).  This addressed the part of https://github.com/veracross/consult/issues/28 to test against multiple ruby versions.

Reviewers - I would like to know your thoughts are on what CircleCI Ruby images we should use for each ruby version being tested -- Do we always want to use the latest image for that ruby version?  The list of tags can be found here: https://hub.docker.com/r/circleci/ruby/tags.

What I am asking is, for testing ruby 2.7 for example, should we use the docker image,  `circleci/ruby:2.7.0` or `circleci/ruby:2.7.1`?

I hope that makes sense.