### PR TITLE
Update rake gem development dependency

### DIFF
--- a/consult.gemspec
+++ b/consult.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'guard'
   spec.add_development_dependency 'guard-rspec'
   spec.add_development_dependency 'pry-byebug'
-  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'rake', '~> 12.3'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rspec_junit_formatter', '~> 0.4.1'
   spec.add_development_dependency 'simplecov'


### PR DESCRIPTION
Update Rake to address security vulnerability detected by Dependabot: https://github.com/veracross/consult/network/alert/consult.gemspec/rake/open