### PR TITLE
Update gemspec version specifiers

### DIFF
--- a/consult.gemspec
+++ b/consult.gemspec
@@ -27,12 +27,12 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'diplomat', '~> 2.0.2'
   spec.add_dependency 'vault', '>= 0.10.0', '< 1.0.0'
 
-  spec.add_development_dependency 'bundler', '~> 1.16'
+  spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'guard'
   spec.add_development_dependency 'guard-rspec'
   spec.add_development_dependency 'pry-byebug'
-  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rspec_junit_formatter', '~> 0.4.1'
-  spec.add_development_dependency 'simplecov'
+  spec.add_development_dependency 'simplecov', '~> 0.16.1'
 end


### PR DESCRIPTION
Supersedes https://github.com/veracross/consult/pull/32/. Per my comment there, we don't need to be opinionated about either bundler or rake. However, pinning SimpleCov is useful (this is the version that I happened to have installed, so I'm pretty sure it works okay).