### PR TITLE
Prepare for 0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+#### 0.9.0
+
+* Add a CLI to render templates on demand ([#20](https://github.com/veracross/consult/pull/20))
+
 #### 0.8.2
 
 * Use `X-Consul-Token` header for Consul authentication. See the [Consul docs](https://www.consul.io/api/index.html#authentication) for details. ([#19](https://github.com/veracross/consult/pull/19))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+#### Unreleased
+
+#### 0.10.0
+
+* Switch from Travis to CircleCI, and set up testing for multiple Ruby versions ([#25](https://github.com/veracross/consult/pull/25) & [#34](https://github.com/veracross/consult/pull/34))
+* Improve development on Windows ([#21](https://github.com/veracross/consult/pull/21))
+* Normalize string encodings to UTF-8 ([#22](https://github.com/veracross/consult/pull/22))
+* Remove dependency on ActiveSupport ([#27](https://github.com/veracross/consult/pull/27))
+
 #### 0.9.0
 
 * Add a CLI to render templates on demand ([#20](https://github.com/veracross/consult/pull/20))

--- a/lib/consult/version.rb
+++ b/lib/consult/version.rb
@@ -1,3 +1,3 @@
 module Consult
-  VERSION = '0.9.0'
+  VERSION = '0.10.0'
 end


### PR DESCRIPTION
#### todo

- [x] add missing 0.9.0 readme
- [x] add readme for 0.10.0 + "unreleased" section (since we should have written that changelog progressively with each PR)
- [x] bump version
- [x] cut [`0.10.0-pre`](https://rubygems.org/gems/consult/versions/0.10.0.pre) and make sure projects with this dependency work okay
- [x] cut `0.10.0` final
