### PR TITLE
Upgrade diplomat gem

### DIFF
--- a/consult.gemspec
+++ b/consult.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.executables   = ['consult']
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'diplomat', '~> 2.0.2'
+  spec.add_dependency 'diplomat', '~> 2.6'
   spec.add_dependency 'vault', '>= 0.10.0', '< 1.0.0'
 
   spec.add_development_dependency 'bundler'

--- a/lib/consult/template_functions.rb
+++ b/lib/consult/template_functions.rb
@@ -16,7 +16,7 @@ module Consult
     ############
     # Consul
     ############
-    def service(key, scope: :all, options: nil, meta: nil)
+    def service(key, scope: :all, options: {}, meta: {})
       Diplomat::Service.get(key, scope, options, meta)
     end
 
@@ -30,7 +30,7 @@ module Consult
       query(*args)&.Nodes&.map { |node| node['Node'] }
     end
 
-    def key(key, options: nil, not_found: :reject, found: :return)
+    def key(key, options: {}, not_found: :reject, found: :return)
       Diplomat::Kv.get(key, options, not_found, found)
     end
 


### PR DESCRIPTION
#### Notes
- Diplomat 2.0.5 uses faray 0.9.0 and with that version the deprecation warning comes up, Diplomat 2.6.4 can use these versions '>= 0.9, != 2.0.0, < 3.0'

#### Test Plan
- Verify all tests pass
