### PR TITLE
Downgrade Diplomat gem to ~> 2.0.5

### DIFF
--- a/consult.gemspec
+++ b/consult.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.executables   = ['consult']
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'diplomat', '~> 2.6'
+  spec.add_dependency 'diplomat', '~> 2.0.5'
   spec.add_dependency 'vault', '>= 0.10.0', '< 1.0.0'
 
   spec.add_development_dependency 'bundler'

--- a/lib/consult/template_functions.rb
+++ b/lib/consult/template_functions.rb
@@ -21,7 +21,7 @@ module Consult
     end
 
     # Execute a prepared query
-    def query(name_or_id, options: nil)
+    def query(name_or_id, options: {})
       Diplomat::Query.execute(name_or_id, options)
     end
 


### PR DESCRIPTION
#### Notes
- Downgrade Diplomat gem to ~> 2.0.5