### PR TITLE
Avoid loading/rendering in Rails if `SKIP_CONSULT` is set

### DIFF
--- a/lib/consult.rb
+++ b/lib/consult.rb
@@ -100,4 +100,6 @@ module Consult
   end
 end
 
-require 'consult/rails/engine' if defined?(Rails)
+if defined?(Rails) && !%w[1 true].include?(ENV['SKIP_CONSULT'].to_s.downcase)
+  require 'consult/rails/engine'
+end


### PR DESCRIPTION
In certain situations, Consult might be loaded by Rails but you don't want it to process templates. For example, from a Rake task that doesn't load the Rails environment. To support those scenarios, you can run the task (etc) with `SKIP_CONSULT=true` and it won't do anything.

I don't think we can do an automated test in this repo for this feature, since otherwise we'd need a dummy Rails app. Adding that might be a good idea for the future, though.

---

**Question**: Is there a better way to do this?