### PR TITLE
Prepare for 0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 #### Unreleased
 
+#### 0.11.0
+
+* Enable support for Ruby 3.1 ([#36](https://github.com/veracross/consult/pull/36))
+* Bump Diplomat version & better testing for default parameters ([#37](https://github.com/veracross/consult/pull/37) & [#39](https://github.com/veracross/consult/pull/39))
+* Avoid loading Railtie if SKIP_CONSULT is truthy ([#40](https://github.com/veracross/consult/pull/40))
+
 #### 0.10.0
 
 * Switch from Travis to CircleCI, and set up testing for multiple Ruby versions ([#25](https://github.com/veracross/consult/pull/25) & [#34](https://github.com/veracross/consult/pull/34))

--- a/lib/consult/version.rb
+++ b/lib/consult/version.rb
@@ -1,3 +1,3 @@
 module Consult
-  VERSION = '0.10.0'
+  VERSION = '0.11.0'
 end


### PR DESCRIPTION
#### Todo

- [x] add missing changelog entries (_we should be better about adding this in each pr_)
- [x] bump version file
- [x] cut [0.11.0-pre](https://rubygems.org/gems/consult/versions/0.11.0.pre) from this branch
- [x] merge & cut 0.11.0 final