### PR TITLE
CLI improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 #### Unreleased
 
+* Development: adjust require's to be able to run CLI from any folder
+
 #### 0.11.0
 
 * Enable support for Ruby 3.1 ([#36](https://github.com/veracross/consult/pull/36))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Stop with error when force rendering and no template is found
 * Remove non-functional short verbosity argument
+* Add `--version` option to show the version
 * Development: adjust require's to be able to run CLI from any folder
 
 #### 0.11.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Stop with error when force rendering and no template is found
 * Remove non-functional short verbosity argument
 * Add `--version` option to show the version
+* Better logging for template rendering status, errors, and config (verbose mode)
 * Development: adjust require's to be able to run CLI from any folder
 
 #### 0.11.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 #### Unreleased
 
+* Stop with error when force rendering and no template is found
 * Development: adjust require's to be able to run CLI from any folder
 
 #### 0.11.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 #### Unreleased
 
 * Stop with error when force rendering and no template is found
+* Remove non-functional short verbosity argument
 * Development: adjust require's to be able to run CLI from any folder
 
 #### 0.11.0

--- a/lib/consult.rb
+++ b/lib/consult.rb
@@ -6,9 +6,9 @@ require 'erb'
 require 'vault'
 require 'diplomat'
 
-require 'consult/version'
-require 'consult/utilities'
-require 'consult/template'
+require_relative './consult/version'
+require_relative './consult/utilities'
+require_relative './consult/template'
 require_relative './support/hash_extensions'
 
 module Consult

--- a/lib/consult.rb
+++ b/lib/consult.rb
@@ -39,6 +39,11 @@ module Consult
 
       @force_render = force_render
 
+      if @templates.empty? && @force_render
+        STDERR.puts "Consult: No template was found for env #{env.inspect} with forced rendering (re-run with `--no-force` if this is acceptable)"
+        exit 1
+      end
+
       configure_consul
       configure_vault
     end

--- a/lib/consult.rb
+++ b/lib/consult.rb
@@ -24,12 +24,18 @@ module Consult
       root directory: config_dir
       yaml = root.join('config', 'consult.yml')
 
+      if verbose
+        puts "Consult: Loading config from #{yaml}"
+      end
+
       @all_config = if yaml.exist?
         if Gem::Version.new(YAML::VERSION) < Gem::Version.new('4.0')
           YAML.safe_load(ERB.new(yaml.read).result, [], [], true, symbolize_names: true).to_h
         else
           YAML.safe_load(ERB.new(yaml.read).result, aliases: true, symbolize_names: true).to_h
         end
+      else
+        STDERR.puts "Consult: No config file found at #{root} -> #{yaml}"
       end
 
       @all_config ||= {}

--- a/lib/consult/cli.rb
+++ b/lib/consult/cli.rb
@@ -38,7 +38,7 @@ module Consult
           opts[:force_render] = arg
         end
 
-        o.on '-v', '--quiet', FalseClass, 'Silence output' do |arg|
+        o.on '--quiet', FalseClass, 'Silence output' do |arg|
           opts[:verbose] = arg
         end
       end

--- a/lib/consult/cli.rb
+++ b/lib/consult/cli.rb
@@ -41,6 +41,11 @@ module Consult
         o.on '--quiet', FalseClass, 'Silence output' do |arg|
           opts[:verbose] = arg
         end
+
+        o.on '--version', 'Show version' do
+          puts "Consult #{Consult::VERSION}"
+          exit 0
+        end
       end
 
       @parser.on_tail "-h", "--help", "Show help" do

--- a/lib/consult/template.rb
+++ b/lib/consult/template.rb
@@ -21,12 +21,13 @@ module Consult
       renderer = ERB.new(contents, nil, '-')
       result = renderer.result(binding)
 
+      puts "Consult: Rendering #{name}" + (save ? " to #{dest}" : "...") if verbose?
       File.open(dest, 'wb') { |f| f << result } if save
-      puts "Consult: Rendered #{name}" if verbose?
       result
     rescue StandardError => e
       STDERR.puts "Error rendering template: #{name}"
       STDERR.puts e
+      STDERR.puts e.backtrace if verbose?
       nil
     end
 

--- a/lib/consult/template.rb
+++ b/lib/consult/template.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'consult/template_functions'
+require_relative 'template_functions'
 
 module Consult
   class Template

--- a/spec/lib/template_spec.rb
+++ b/spec/lib/template_spec.rb
@@ -50,9 +50,9 @@ RSpec.describe Consult::Template do
   end
 
   it 'supports verbose output' do
-    t = Consult::Template.new 'verbose', config.merge(verbose: true)
+    t = Consult::Template.new 'verbose-template', config.merge(verbose: true)
     expect(t.verbose?).to be(true)
-    expect { t.render }.to output(/Consult: Rendered verbose/i).to_stdout_from_any_process
+    expect { t.render }.to output(/Consult: Rendering verbose-template.../).to_stdout_from_any_process
   end
 
   it 'outputs render failures to stderr' do


### PR DESCRIPTION
Here's some improvements I came up with while working on other things. Per the changelog:

* Stop with error when force rendering and no template is found
* Remove non-functional short verbosity argument
* Add `--version` option to show the version
* Better logging for template rendering status, errors, and config (verbose mode)
* Development: adjust require's to be able to run CLI from any folder
