### PR TITLE
Enable defining vars at the env block level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Add `--version` option to show the version
 * Better logging for template rendering status, errors, and config (verbose mode)
 * Development: adjust require's to be able to run CLI from any folder
+* Enable defining vars at the env block level, rather than only on template blocks
 
 #### 0.11.0
 

--- a/README.md
+++ b/README.md
@@ -94,8 +94,15 @@ test:
     secrets:
       path: config/templates/secrets.yml
       dest: config/secrets.yml
+      # vars can be defined on a per-template basis
+      vars:
+        test_specific_key: and_the_value
 
 production:
+  # vars can be defined at the environment level, which are available to these templates
+  vars:
+    hello: world
+
   templates:
     # You can concatenate multiple files together
     my_config:

--- a/lib/consult.rb
+++ b/lib/consult.rb
@@ -41,7 +41,7 @@ module Consult
       @all_config ||= {}
 
       @config = @all_config[:shared].to_h.deep_merge @all_config[env&.to_sym].to_h
-      @templates = @config[:templates]&.map { |name, config| Template.new(name, config.merge(verbose: verbose)) } || []
+      @templates = @config[:templates]&.map { |name, config| Template.new(name, config.merge({verbose: verbose, env_vars: @config[:vars]})) } || []
 
       @force_render = force_render
 

--- a/lib/consult/template.rb
+++ b/lib/consult/template.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative 'template_functions'
+require_relative '../support/hash_extensions'
 
 module Consult
   class Template
@@ -40,7 +41,7 @@ module Consult
     end
 
     def vars
-      @config[:vars]
+      @config[:env_vars].to_h.deep_merge @config[:vars].to_h
     end
 
     def dest

--- a/spec/lib/template_spec.rb
+++ b/spec/lib/template_spec.rb
@@ -95,6 +95,34 @@ RSpec.describe Consult::Template do
       expect(template.key('infrastructure/db1/dns')).to eq 'db1.local.net'
     end
 
+    describe '#vars' do
+      let(:env_vars) do
+        {
+          env_vars: {
+            'test_env_override' => 'some value from env vars',
+          },
+        }
+      end
+
+      let(:env_vars_and_template_vars) do
+        env_vars.merge({
+          vars: {
+            'test_var_override' => 'some value from template vars',
+          },
+        })
+      end
+
+      it 'can read vars from environment block' do
+        config.merge! env_vars
+        expect(template.vars['test_env_override']).to eq 'some value from env vars'
+      end
+
+      it 'can read vars from vars block' do
+        config.merge! env_vars_and_template_vars
+        expect(template.vars['test_var_override']).to eq 'some value from template vars'
+      end
+    end
+
     it '#with' do
       expect { |b| template.with(0, &b) }.to yield_control
     end

--- a/spec/support/config/consult.yml
+++ b/spec/support/config/consult.yml
@@ -83,6 +83,9 @@ shared:
         aziz: 'Light!'
 
 test:
+  vars:
+    test_env_override: some value
+
   templates:
     secrets:
       path: templates/secrets.yml.erb

--- a/spec/support/templates/database.yml.erb
+++ b/spec/support/templates/database.yml.erb
@@ -1,4 +1,6 @@
 # rendered at <%= timestamp %>
+# additional var: <%= vars.dig 'test_env_override' %>
+
 common: &common
   appname: Rails
   adapter: postgres


### PR DESCRIPTION
Enable defining vars at the env block level, rather than only on template blocks. This makes it easy to set up a series of vars once that are available to all the templates. You can still override a var on a per-template basis if needed.