### PR TITLE
Template validation

### DIFF
--- a/bin/consult
+++ b/bin/consult
@@ -1,6 +1,7 @@
 #!/usr/bin/env ruby
 
-require_relative '../lib/consult/cli'
+require 'bundler/setup'
+require 'consult/cli'
 
 cli = Consult::CLI.instance
 cli.parse

--- a/consult.gemspec
+++ b/consult.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'diplomat', '~> 2.6'
   spec.add_dependency 'vault', '>= 0.10.0', '< 1.0.0'
+  spec.add_dependency 'dry-validation', '<= 1.9.0'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'guard'

--- a/lib/consult.rb
+++ b/lib/consult.rb
@@ -100,6 +100,13 @@ module Consult
       active_templates.each(&:render)
     end
 
+    def validate_templates
+      active_templates do |t|
+        t.validate
+        puts "#{t.name}: #{t.validation.errors}"
+      end
+    end
+
     # Map more conventional `token` parameter to Diplomat's `acl_token` configuration.
     # Additionally, we support ~/.consul-token, similar to Vault's support for ~/.vault-token
     def consul_token

--- a/lib/consult/cli.rb
+++ b/lib/consult/cli.rb
@@ -19,6 +19,7 @@ module Consult
     end
 
     def render
+      Consult.validate_templates
       Consult.render!
     end
 

--- a/lib/consult/template.rb
+++ b/lib/consult/template.rb
@@ -25,7 +25,11 @@ module Consult
       end
 
       # Attempt to render
-      renderer = ERB.new(contents, trim_mode: '-')
+      renderer = if legacy_erb_args?
+        ERB.new(contents, nil, '-')
+      else
+        ERB.new(contents, trim_mode: '-')
+      end
       result = renderer.result(binding)
 
       puts "Consult: Rendering #{name}" + (save ? " to #{dest}" : "...") if verbose?
@@ -82,6 +86,13 @@ module Consult
     end
 
     private
+
+    def legacy_erb_args?
+      # prior to 2.2.2 ERB.version was a string rather than a Gem::Version-compatible version number, so this will raise an exception
+      Gem::Version.new(ERB.version) < Gem::Version.new('2.2.0')
+    rescue
+      true
+    end
 
     # Concatenate all the source templates together, in the order provided
     def contents

--- a/lib/consult/template.rb
+++ b/lib/consult/template.rb
@@ -2,6 +2,7 @@
 
 require 'fileutils'
 require_relative 'template_functions'
+require_relative 'template_schema'
 require_relative '../support/hash_extensions'
 
 module Consult
@@ -24,7 +25,7 @@ module Consult
       end
 
       # Attempt to render
-      renderer = ERB.new(contents, nil, '-')
+      renderer = ERB.new(contents, trim_mode: '-')
       result = renderer.result(binding)
 
       puts "Consult: Rendering #{name}" + (save ? " to #{dest}" : "...") if verbose?
@@ -74,6 +75,10 @@ module Consult
 
     def ordered_locations
       @config.keys & LOCATIONS
+    end
+
+    def validate
+      @validation = TemplateSchema.new.call(@config)
     end
 
     private

--- a/lib/consult/template_schema.rb
+++ b/lib/consult/template_schema.rb
@@ -1,0 +1,30 @@
+# frozen_string-literal: true
+
+require 'dry-validation'
+
+class TemplateSchema < Dry::Validation::Contract
+  schema do
+    # Output destination is required
+    required(:dest).value(:string)
+
+    # At least one of path/paths/consul_key/consul_keys is required
+    optional(:path).value(:string)
+    optional(:paths).value(:array)
+    optional(:consul_key).value(:string)
+    optional(:consul_keys).value(:array)
+
+    # Other configuration
+    optional(:ttl).value(:integer)
+    optional(:vars).value(:hash)
+  end
+
+  rule(:path, :paths, :consul_key, :consul_keys) do
+    unless key?(:path) || key?(:paths) || key?(:consul_key) || key?(:consul_keys)
+      base.failure("A template source must be specified. Please provide one or more of: path, paths, consul_key, consul_keys")
+    end
+  end
+
+  rule(:ttl) do
+    key.failure "A TTL is strongly recommended to avoid rendering templates too often, especially in multi-process environments." if value.to_i == 0
+  end
+end

--- a/spec/support/config/consult.yml
+++ b/spec/support/config/consult.yml
@@ -87,6 +87,9 @@ shared:
       path: x/y/z.txt
       dest: rendered/nope/skip_missing_template
 
+    missing_source:
+      dest: rendered/nowhere.txt
+
 test:
   vars:
     test_env_override: some value


### PR DESCRIPTION
This is a very draft-level initial commit of some template validation logic. At this stage, I am mostly pushing the files as a backup, and to trigger discussion.

This uses `dry-validation` to define a schema for the section of `consult.yml` that defines individual templates. In the current form, it does not validate the entire `consult.yml` file.

### Goals

1. Provide visibility into obvious configuration errors (e.g., having no source or destination configured).
2. Encourage best practice configuration, such as setting a TTL.

### Caveats

There are changes in here (`bin/consult`, as well as the ERB API change in `template.rb`) that are not related to template validation that I needed to make to get the code to run properly. I have not debugged why. 