### PR TITLE
Create directories for rendered files as needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Better logging for template rendering status, errors, and config (verbose mode)
 * Development: adjust require's to be able to run CLI from any folder
 * Enable defining vars at the env block level, rather than only on template blocks
+* Create directories for rendered files as needed
 
 #### 0.11.0
 

--- a/lib/consult/template.rb
+++ b/lib/consult/template.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'fileutils'
 require_relative 'template_functions'
 require_relative '../support/hash_extensions'
 
@@ -23,7 +24,12 @@ module Consult
       result = renderer.result(binding)
 
       puts "Consult: Rendering #{name}" + (save ? " to #{dest}" : "...") if verbose?
-      File.open(dest, 'wb') { |f| f << result } if save
+
+      if save
+        FileUtils.mkdir_p(dest.dirname) unless dest.dirname.exist?
+        File.open(dest, 'wb') { |f| f << result }
+      end
+
       result
     rescue StandardError => e
       STDERR.puts "Error rendering template: #{name}"

--- a/spec/lib/template_spec.rb
+++ b/spec/lib/template_spec.rb
@@ -11,9 +11,9 @@ RSpec.describe Consult::Template do
   end
   let(:fail_config) do
     {
-      consul_key: 'templates/elements/aziz',
+      consul_key: 'templates/var-missing',
       dest: 'rendered/nope/dest_fail.keep',
-      vars: {aziz: 'Light!'}
+      vars: {another_var: 'another value'}
     }
   end
   let(:template) { Consult::Template.new(name, config) }

--- a/spec/support/populate_consul.sh
+++ b/spec/support/populate_consul.sh
@@ -35,6 +35,12 @@ curl \
 curl \
     --request PUT \
     -H "Content-Type: application/x-www-form-urlencoded; charset=utf-8" \
+    --data $'<%= vars.fetch(:missing) %>\n' \
+    http://localhost:8500/v1/kv/templates/var-missing
+
+curl \
+    --request PUT \
+    -H "Content-Type: application/x-www-form-urlencoded; charset=utf-8" \
     --data-binary @spec/support/templates/query-test.yml.erb \
     http://localhost:8500/v1/kv/templates/db/db1
 


### PR DESCRIPTION
This avoids having to create folders ahead of time, potentially empty ones with `.keep` files. There was a test for template rendering failure that assumed that a missing directory would cause a failure, so I switched it to a more plausible failure (missing required variable).