### PR TITLE
Run the support script via a less opinionated shell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Add `--version` option to show the version
 * Better logging for template rendering status, errors, and config (verbose mode)
 * Development: adjust require's to be able to run CLI from any folder
+* Enable defining vars at the env block level, rather than only on template blocks
 
 #### 0.11.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Stop with error when force rendering and no template is found
 * Remove non-functional short verbosity argument
 * Add `--version` option to show the version
+* Better logging for template rendering status, errors, and config (verbose mode)
 * Development: adjust require's to be able to run CLI from any folder
 
 #### 0.11.0

--- a/README.md
+++ b/README.md
@@ -94,8 +94,15 @@ test:
     secrets:
       path: config/templates/secrets.yml
       dest: config/secrets.yml
+      # vars can be defined on a per-template basis
+      vars:
+        test_specific_key: and_the_value
 
 production:
+  # vars can be defined at the environment level, which are available to these templates
+  vars:
+    hello: world
+
   templates:
     # You can concatenate multiple files together
     my_config:

--- a/lib/consult.rb
+++ b/lib/consult.rb
@@ -41,7 +41,7 @@ module Consult
       @all_config ||= {}
 
       @config = @all_config[:shared].to_h.deep_merge @all_config[env&.to_sym].to_h
-      @templates = @config[:templates]&.map { |name, config| Template.new(name, config.merge(verbose: verbose)) } || []
+      @templates = @config[:templates]&.map { |name, config| Template.new(name, config.merge(verbose: verbose).merge(env_vars: @config[:vars])) } || []
 
       @force_render = force_render
 

--- a/lib/consult.rb
+++ b/lib/consult.rb
@@ -24,12 +24,18 @@ module Consult
       root directory: config_dir
       yaml = root.join('config', 'consult.yml')
 
+      if verbose
+        puts "Consult: Loading config from #{yaml}"
+      end
+
       @all_config = if yaml.exist?
         if Gem::Version.new(YAML::VERSION) < Gem::Version.new('4.0')
           YAML.safe_load(ERB.new(yaml.read).result, [], [], true, symbolize_names: true).to_h
         else
           YAML.safe_load(ERB.new(yaml.read).result, aliases: true, symbolize_names: true).to_h
         end
+      else
+        STDERR.puts "Consult: No config file found at #{root} -> #{yaml}"
       end
 
       @all_config ||= {}

--- a/lib/consult/template.rb
+++ b/lib/consult/template.rb
@@ -21,12 +21,13 @@ module Consult
       renderer = ERB.new(contents, nil, '-')
       result = renderer.result(binding)
 
+      puts "Consult: Rendering #{name}" + (save ? " to #{dest} ..." : "...") if verbose?
       File.open(dest, 'wb') { |f| f << result } if save
-      puts "Consult: Rendered #{name}" if verbose?
       result
     rescue StandardError => e
       STDERR.puts "Error rendering template: #{name}"
       STDERR.puts e
+      STDERR.puts e.backtrace if verbose?
       nil
     end
 

--- a/lib/consult/template.rb
+++ b/lib/consult/template.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative 'template_functions'
+require_relative '../support/hash_extensions'
 
 module Consult
   class Template
@@ -40,7 +41,7 @@ module Consult
     end
 
     def vars
-      @config[:vars]
+      @config[:env_vars].to_h.deep_merge @config[:vars].to_h
     end
 
     def dest

--- a/spec/lib/template_spec.rb
+++ b/spec/lib/template_spec.rb
@@ -50,9 +50,9 @@ RSpec.describe Consult::Template do
   end
 
   it 'supports verbose output' do
-    t = Consult::Template.new 'verbose', config.merge(verbose: true)
+    t = Consult::Template.new 'verbose-template', config.merge(verbose: true)
     expect(t.verbose?).to be(true)
-    expect { t.render }.to output(/Consult: Rendered verbose/i).to_stdout_from_any_process
+    expect { t.render }.to output(/Consult: Rendering verbose-template.../).to_stdout_from_any_process
   end
 
   it 'outputs render failures to stderr' do

--- a/spec/lib/template_spec.rb
+++ b/spec/lib/template_spec.rb
@@ -95,6 +95,34 @@ RSpec.describe Consult::Template do
       expect(template.key('infrastructure/db1/dns')).to eq 'db1.local.net'
     end
 
+    describe '#vars' do
+      let(:env_vars) do
+        {
+          env_vars: {
+            'test_env_override' => 'some value from env vars',
+          },
+        }
+      end
+
+      let(:env_vars_and_template_vars) do
+        env_vars.merge({
+          vars: {
+            'test_var_override' => 'some value from template vars',
+          },
+        })
+      end
+
+      it 'can read vars from environment block' do
+        config.merge! env_vars
+        expect(template.vars['test_env_override']).to eq 'some value from env vars'
+      end
+
+      it 'can read vars from vars block' do
+        config.merge! env_vars_and_template_vars
+        expect(template.vars['test_var_override']).to eq 'some value from template vars'
+      end
+    end
+
     it '#with' do
       expect { |b| template.with(0, &b) }.to yield_control
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,6 +19,6 @@ RSpec.configure do |config|
 
   config.before(:suite) do
     puts 'Populating consul & vault...'
-    system '/bin/bash spec/support/populate_consul.sh'
+    system 'sh spec/support/populate_consul.sh'
   end
 end

--- a/spec/support/config/consult.yml
+++ b/spec/support/config/consult.yml
@@ -83,6 +83,9 @@ shared:
         aziz: 'Light!'
 
 test:
+  vars:
+    test_env_override: some value
+
   templates:
     secrets:
       path: templates/secrets.yml.erb

--- a/spec/support/templates/database.yml.erb
+++ b/spec/support/templates/database.yml.erb
@@ -1,4 +1,6 @@
 # rendered at <%= timestamp %>
+# additional var: <%= vars.dig 'test_env_override' %>
+
 common: &common
   appname: Rails
   adapter: postgres


### PR DESCRIPTION
Everybody has a "sh", but not everybody uses bash. The script file itself seems to work fine, ~I don't think we were using any bash-isms anyway.~ actually, the `$"` is a bash-ism, so populate_consul.sh will also need to be updated if this is accepted.