### PR TITLE
Add configuration to allow skipping missing template files/keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Development: adjust require's to be able to run CLI from any folder
 * Enable defining vars at the env block level, rather than only on template blocks
 * Create directories for rendered files as needed
+* Add the `skip_missing_template` config for templates
 
 #### 0.11.0
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,13 @@ test:
       vars:
         test_specific_key: and_the_value
 
+    extra_test_config:
+      # normally there's an error for missing templates, but this can be allowed via config
+      skip_missing_template: true
+      # config files are also processed through ERB, so paths can be made dynamic
+      path: config/templates/<%= ENV['extra_test_file'] %>.yml
+      dest: config/extra_test_config.yml
+
 production:
   # vars can be defined at the environment level, which are available to these templates
   vars:

--- a/lib/consult/template.rb
+++ b/lib/consult/template.rb
@@ -83,7 +83,7 @@ module Consult
 
     def consul_contents(location)
       [@config[location]].compact.flatten.map do |key|
-        Diplomat::Kv.get(key, options: {}, not_found: :return, found: :return).force_encoding 'utf-8'
+        Diplomat::Kv.get(key, {}, :return, :return).force_encoding 'utf-8'
       end.join
     end
 

--- a/spec/support/config/consult.yml
+++ b/spec/support/config/consult.yml
@@ -82,6 +82,11 @@ shared:
       vars:
         aziz: 'Light!'
 
+    missing_template_file:
+      skip_missing_template: true
+      path: x/y/z.txt
+      dest: rendered/nope/skip_missing_template
+
 test:
   vars:
     test_env_override: some value


### PR DESCRIPTION
This PR introduces `skip_missing_template: true` optional config for templates, which allows configured templates to not exist. This builds in the feature that you'd overwise have to work around with ERB logic in the consult config file itself. Eg, it replaces this:

```erb
    <% path = File.join("./config/templates/#{ENV['AWS_REGION']}.json.erb") %>
    <% if File.exist? path %>
    region-config:
      path: config/templates/<%= ENV['AWS_REGION'] %>.json.erb
      dest: config/region.json
    <% else %>
    <% puts "Consult: No #{ENV['AWS_REGION']}.json.erb present, skipping..." %>
    <% end %>
```