### PR TITLE
Add config & CLI option for "raise on error"

### DIFF
--- a/lib/consult.rb
+++ b/lib/consult.rb
@@ -22,7 +22,7 @@ module Consult
   class << self
     attr_reader :config, :templates, :force_render
 
-    def load(config_dir: nil, force_render: false, verbose: nil)
+    def load(config_dir: nil, force_render: false, raise_on_error: false, verbose: nil)
       root directory: config_dir
       yaml = root.join('config', 'consult.yml')
 

--- a/lib/consult/cli.rb
+++ b/lib/consult/cli.rb
@@ -26,6 +26,7 @@ module Consult
       opts = {
         config_dir: Dir.pwd,
         force_render: true,
+        raise_on_error: false,
         verbose: true
       }
 
@@ -36,6 +37,10 @@ module Consult
 
         o.on '-f', '--[no-]force', TrueClass, 'Ignore template TTLs and force rendering' do |arg|
           opts[:force_render] = arg
+        end
+
+        o.on '--raise-on-error', FalseClass, 'Raise errors instead of printing them' do |arg|
+          opts[:raise_on_error] = arg
         end
 
         o.on '--quiet', FalseClass, 'Silence output' do |arg|

--- a/lib/consult/template.rb
+++ b/lib/consult/template.rb
@@ -41,6 +41,11 @@ module Consult
       result
     rescue StandardError => e
       STDERR.puts "Error rendering template: #{name}"
+
+      if @config[:raise_on_error]
+        raise e
+      end
+
       STDERR.puts e
       STDERR.puts e.backtrace if verbose?
       nil


### PR DESCRIPTION
This PR adds an option to raise exceptions for templating errors. That way the thing running Consult will stop (perhaps this should be called "stop on error" 🤔).