### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM ruby:3.1
+
+WORKDIR /consult
+
+COPY Gemfile consult.gemspec ./
+COPY lib/consult/version.rb ./lib/consult/version.rb
+RUN bundle package --all --no-install
+RUN bundle install
+
+COPY . .
+
+ENTRYPOINT ["ruby", "bin/consult"]
+CMD ["--help"]

--- a/README.md
+++ b/README.md
@@ -48,6 +48,14 @@ Consult: Rendered my_config
 Consult: Rendered secrets
 ```
 
+The Consult CLI is also available via Docker:
+
+```bash
+$ docker run --rm -v .:/app veracross/consult:latest --directory /app
+```
+
+If your templates reference `localhost` (such as the templates in the `spec` directory of this repo), add `--net host` to the command.
+
 ### Configuration
 
 ```yaml


### PR DESCRIPTION
The idea here is to make it easier to run Consult in environments where we might not want to install Ruby (eg, CI workers, etc).

The Docker image is automatically built for each PR, and is also public like this repo is: https://hub.docker.com/r/veracross/consult