### PR TITLE
Set template working dir to config root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM ruby:3.1
+
+WORKDIR /consult
+
+COPY Gemfile consult.gemspec ./
+COPY lib/consult/version.rb ./lib/consult/version.rb
+RUN bundle package --all --no-install
+RUN bundle install
+
+COPY . .
+
+ENTRYPOINT ["ruby", "bin/consult"]
+CMD ["--help"]

--- a/README.md
+++ b/README.md
@@ -48,6 +48,14 @@ Consult: Rendered my_config
 Consult: Rendered secrets
 ```
 
+The Consult CLI is also available via Docker:
+
+```bash
+$ docker run --rm -v .:/app veracross/consult:latest --directory /app
+```
+
+If your templates reference `localhost` (such as the templates in the `spec` directory of this repo), add `--net host` to the command.
+
 ### Configuration
 
 ```yaml

--- a/lib/consult.rb
+++ b/lib/consult.rb
@@ -40,8 +40,12 @@ module Consult
 
       @all_config ||= {}
 
-      @config = @all_config[:shared].to_h.deep_merge @all_config[env&.to_sym].to_h
-      @templates = @config[:templates]&.map { |name, config| Template.new(name, config.merge({root: root, verbose: verbose, env_vars: @config[:vars]})) } || []
+      @config = @all_config[:shared].to_h.deep_merge @all_config[env&.to_sym].to_h.merge({
+        config_dir: config_dir,
+        verbose: verbose,
+        env_vars: @config[:vars],
+      })
+      @templates = @config[:templates]&.map { |name, config| Template.new(name, @config) } || []
 
       @force_render = force_render
 

--- a/lib/consult.rb
+++ b/lib/consult.rb
@@ -20,7 +20,7 @@ module Consult
   class << self
     attr_reader :config, :templates, :force_render
 
-    def load(config_dir: nil, force_render: false, verbose: nil)
+    def load(config_dir: nil, force_render: false, raise_on_error: false, verbose: nil)
       root directory: config_dir
       yaml = root.join('config', 'consult.yml')
 

--- a/lib/consult.rb
+++ b/lib/consult.rb
@@ -41,7 +41,7 @@ module Consult
       @all_config ||= {}
 
       @config = @all_config[:shared].to_h.deep_merge @all_config[env&.to_sym].to_h
-      @templates = @config[:templates]&.map { |name, config| Template.new(name, config.merge({verbose: verbose, env_vars: @config[:vars]})) } || []
+      @templates = @config[:templates]&.map { |name, config| Template.new(name, config.merge({root: root, verbose: verbose, env_vars: @config[:vars]})) } || []
 
       @force_render = force_render
 

--- a/lib/consult/cli.rb
+++ b/lib/consult/cli.rb
@@ -26,6 +26,7 @@ module Consult
       opts = {
         config_dir: Dir.pwd,
         force_render: true,
+        raise_on_error: false,
         verbose: true
       }
 
@@ -36,6 +37,10 @@ module Consult
 
         o.on '-f', '--[no-]force', TrueClass, 'Ignore template TTLs and force rendering' do |arg|
           opts[:force_render] = arg
+        end
+
+        o.on '--raise-on-error', FalseClass, 'Raise errors instead of printing them' do |arg|
+          opts[:raise_on_error] = arg
         end
 
         o.on '--quiet', FalseClass, 'Silence output' do |arg|

--- a/lib/consult/template.rb
+++ b/lib/consult/template.rb
@@ -23,6 +23,10 @@ module Consult
         return
       end
 
+      if config.key?(:root)
+        Dir.chdir(Pathname.new(config[:root]).parent)
+      end
+
       # Attempt to render
       renderer = ERB.new(contents, nil, '-')
       result = renderer.result(binding)

--- a/lib/consult/template.rb
+++ b/lib/consult/template.rb
@@ -37,6 +37,11 @@ module Consult
       result
     rescue StandardError => e
       STDERR.puts "Error rendering template: #{name}"
+
+      if @config[:raise_on_error]
+        raise e
+      end
+
       STDERR.puts e
       STDERR.puts e.backtrace if verbose?
       nil

--- a/lib/consult/template.rb
+++ b/lib/consult/template.rb
@@ -23,9 +23,20 @@ module Consult
         return
       end
 
-      if config.key?(:root)
-        Dir.chdir(Pathname.new(config[:root]).parent)
-      end
+      puts @config[:config_dir].inspect
+      puts Pathname.new(@config[:config_dir]).parent
+
+      puts "before"
+      puts Dir.pwd.inspect
+      puts Dir.entries('.').inspect
+
+      # if @config.key?(:config_dir)
+      #   Dir.chdir(Pathname.new(@config[:config_dir]))
+      # end
+
+      # puts "after"
+      # puts Dir.pwd.inspect
+      # puts Dir.entries('.').inspect
 
       # Attempt to render
       renderer = ERB.new(contents, nil, '-')
@@ -36,6 +47,16 @@ module Consult
       if save
         FileUtils.mkdir_p(dest.dirname) unless dest.dirname.exist?
         File.open(dest, 'wb') { |f| f << result }
+
+        puts "saving..."
+        puts Dir.pwd.inspect
+        puts Dir.entries('.').inspect
+
+        Dir.chdir(dest.dirname) do
+          puts "inside..."
+          puts Dir.pwd.inspect
+          puts Dir.entries('.').inspect
+        end
       end
 
       result


### PR DESCRIPTION
Templates that read files should be able to expect them in terms of the Consult config. This matches the expectation for `path` and `dest` for templates, which are also relative to the config file.