### PR TITLE
Fix ERB deprecated warnings in Ruby 3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
     strategy:
       matrix:
         ruby-version:
+          - '2.5'
           - '2.7'
           - '3.0'
           - '3.1'

--- a/lib/consult/template.rb
+++ b/lib/consult/template.rb
@@ -24,7 +24,11 @@ module Consult
       end
 
       # Attempt to render
-      renderer = ERB.new(contents, nil, '-')
+      renderer = if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.7.0')
+        ERB.new(contents, trim_mode: '-')
+      else
+        ERB.new(contents, nil, '-')
+      end
       result = renderer.result(binding)
 
       puts "Consult: Rendering #{name}" + (save ? " to #{dest}" : "...") if verbose?


### PR DESCRIPTION
- This PR fixes the following deprecated warnings:
  -  Passing trim_mode with the 3rd argument of ERB.new is deprecated. Use keyword argument like ERB.new(str, trim_mode: ...) instead.
  - Passing safe_level with the 2nd argument of ERB.new is deprecated. Do not use it, and specify other arguments as keyword arguments

We're going to drop Ruby 2.5 from the CI matrix, right?