### PR TITLE
Raise an error when rendering fails and there's no `dest` file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 #### Unreleased
 
+* Raise an error when rendering fails and there's no `dest` file (eg, when the app boots)
+
 #### 1.0.0
 
 * Stop with error when force rendering and no template is found

--- a/lib/consult/template.rb
+++ b/lib/consult/template.rb
@@ -41,9 +41,12 @@ module Consult
       result
     rescue StandardError => e
       STDERR.puts "Error rendering template: #{name}"
-      STDERR.puts e
-      STDERR.puts e.backtrace if verbose?
-      nil
+      if dest.exist?
+        STDERR.puts e.backtrace if verbose?
+        STDERR.puts e
+      else
+        raise e
+      end
     end
 
     def path

--- a/spec/lib/template_spec.rb
+++ b/spec/lib/template_spec.rb
@@ -75,6 +75,18 @@ RSpec.describe Consult::Template do
     expect { fail_template.render }.to output(/Error rendering template*/).to_stderr_from_any_process
   end
 
+  it 'raises error for render failures when `dest` file does not exist' do
+    fail_template.dest.delete if fail_template.dest.exist?
+    expect { fail_template.render }.to raise_error(StandardError)
+  end
+
+  it 'logs error and continues for render failures when `dest` file exists' do
+    fail_template.dest.dirname.mkpath unless fail_template.dest.dirname.exist?
+    File.write(fail_template.dest, 'existing content')
+    expect { fail_template.render }.to output(/Error rendering template/).to_stderr_from_any_process
+    expect(fail_template.render).to be_nil
+  end
+
   context 'skip_missing_template' do
     it 'allows missing template files' do
       expect { missing_template_file.render }.to output(/Consult: Skipping missing template: missing/).to_stderr_from_any_process


### PR DESCRIPTION
This solves the problem of the app booting "successfully" when it can't render key files, eg databases.yml. It seems better to fail to start the app rather than waiting for the first ActiveRecord query to show a runtime error.

This PR supersedes https://github.com/veracross/consult/pull/49. I have temporarily re-tagged `veracross/consul:error-failing-render-without-dest` as `veracross/consul:latest` to validate.

#### Test Plan

new behavior: app won't boot on render failure (w/o dest file)

1. set up a repo with Consult to render `config/database.yml` from Consul
2. `CONSUL_HTTP_ADDR=fake bundle exec rails s`
3. verify an error is shown & the app halts

control case: app will boot on render failure (w/ dest file)

1. `touch config/database.yml`
2. `CONSUL_HTTP_ADDR=fake bundle exec rails s`
3. verify an error is logged but the app starts up normally