### PR TITLE
Refresh Vault token from disk on each Consult.load call

### DIFF
--- a/lib/consult.rb
+++ b/lib/consult.rb
@@ -78,6 +78,11 @@ module Consult
       return unless @config.key? :vault
 
       Vault.configure do |c|
+        # Re-read token from disk
+        # Fall back to Vault::Defaults.token when no usable token is explicitly configured
+        configured_token = @config.dig(:vault, :token)
+        c.token = Vault::Defaults.token if configured_token.nil? || configured_token.to_s.empty?
+
         @config[:vault].each do |opt, val|
           c.send "#{opt}=".to_sym, val
         end

--- a/spec/consult_spec.rb
+++ b/spec/consult_spec.rb
@@ -44,4 +44,32 @@ RSpec.describe Consult do
     Consult.render!
     expect(Consult.active_templates).to eq Consult.templates
   end
+
+  context 'configure_vault token refresh' do
+    before { Consult.load config_dir: directory }
+
+    it 'refreshes the Vault client token from Defaults.token on each call to configure_vault when no token is in config' do
+      # Simulate production consult.yml (no explicit token; vault-agent manages it)
+      Consult.config[:vault].delete(:token)
+
+      allow(Vault::Defaults).to receive(:token).and_return('new-refreshed-token')
+
+      # Reconfigure Vault with the current token from Vault::Defaults
+      Consult.configure_vault
+
+      expect(Vault.client.token).to eq('new-refreshed-token')
+    end
+
+    it 'updates the token on every call to configure_vault when no token is in config' do
+      Consult.config[:vault].delete(:token)
+
+      allow(Vault::Defaults).to receive(:token).and_return('first-token')
+      Consult.configure_vault
+      expect(Vault.client.token).to eq('first-token')
+
+      allow(Vault::Defaults).to receive(:token).and_return('second-token')
+      Consult.configure_vault
+      expect(Vault.client.token).to eq('second-token')
+    end
+  end
 end


### PR DESCRIPTION
The Vault Ruby gem caches the token in memory at client initialization and never re-reads. The token is being renewed and  written to a shared volume (symlinked to ~/.vault-token), but the running Rails process keeps using the stale cached token. This causes 403 "invalid token" errors when templates are re-rendered at runtime.

Adding `c.token = Vault::Defaults.token` to configure_vault forces the client to re-read the token from ~/.vault-token on every Consult.load call, picking up vault-agent's renewed token.

#### Test Plan
**1. Start a console session**

```sh
bin/console
```

**2. Load config and remove the explicit token**

```ruby
Consult.load config_dir: 'spec/support'
Consult.config[:vault].delete(:token)
```

This simulates a production consult.yml key, relying on a local token agent instead.

**3. Write a first token to disk**

```sh
echo 'first-token' > ~/.vault-token
```

**4. Call configure_vault and verify**

```ruby
Consult.configure_vault
Vault.client.token # => "first-token"
```

**5. Simulate a token rotation**

In a separate terminal:

```sh
echo 'second-token' > ~/.vault-token
```

**6. Call configure_vault again and confirm the new token is picked up**

```ruby
Consult.configure_vault
Vault.client.token # => "second-token"
```

**7. Restore your real Vault token when done**

```sh
vcli init --force
```